### PR TITLE
Added Date format commonly found in germany

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub fn parse_date(string: &str) -> Option<DateTime<FixedOffset>> {
         .or_else(|| utc_date(trimmed, "%B %d, %Y"))
         .or_else(|| utc_date(trimmed, "%B %e, %Y"))
         .or_else(|| utc_date(trimmed, "%m/%d/%Y"))
+        .or_else(|| utc_date(trimmed, "%d.%m.%Y"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hey, so for my usecase I wanted the library to also parse the date format commonly used in germany (and I think some other european countries).

For example:
17.07.2020

So here is a pullrequest if you want to officially support it